### PR TITLE
Add `xmlns` automatically

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -7,7 +7,7 @@ export function encode(code) {
         .replace(/#/g, '%23');
 }
 
-export function xmlns(code) {
+export function xmlnsize(code) {
     if (code.indexOf('xmlns') === -1) {
         return code
             .replace(/<svg/g, '<svg xmlns="http://www.w3.org/2000/svg"');

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -7,6 +7,15 @@ export function encode(code) {
         .replace(/#/g, '%23');
 }
 
+export function xmlns(code) {
+    if (code.indexOf('xmlns') === -1) {
+        return code
+            .replace(/<svg/g, '<svg xmlns="http://www.w3.org/2000/svg"');
+    } else {
+        return code;
+    }
+}
+
 function normalize(code) {
     return code
         .replace(/'/g, '%22')

--- a/src/load.js
+++ b/src/load.js
@@ -1,6 +1,6 @@
 import { readFile } from 'fs';
 import render from './render.js';
-import { transform, encode, xmlns } from './defaults.js';
+import { transform, encode, xmlnsize } from './defaults.js';
 import { removeFill, applyRootParams, applySelectedParams } from './processors.js';
 
 function read(id) {
@@ -24,12 +24,12 @@ export default function load(id, params, selectors, opts) {
     return read(id).then(data => {
         let code = render(data, ...processors);
 
-        if (opts.encode !== false) {
-            code = (opts.encode || encode)(code);
+        if (opts.xmlnsize !== false) {
+            code = (opts.xmlnsize || xmlnsize)(code);
         }
 
-        if (opts.xmlns !== false) {
-            code = (opts.xmlns || xmlns)(code);
+        if (opts.encode !== false) {
+            code = (opts.encode || encode)(code);
         }
 
         if (opts.transform !== false) {

--- a/src/load.js
+++ b/src/load.js
@@ -1,6 +1,6 @@
 import { readFile } from 'fs';
 import render from './render.js';
-import { transform, encode } from './defaults.js';
+import { transform, encode, xmlns } from './defaults.js';
 import { removeFill, applyRootParams, applySelectedParams } from './processors.js';
 
 function read(id) {
@@ -26,6 +26,10 @@ export default function load(id, params, selectors, opts) {
 
         if (opts.encode !== false) {
             code = (opts.encode || encode)(code);
+        }
+
+        if (opts.xmlns !== false) {
+            code = (opts.xmlns || xmlns)(code);
         }
 
         if (opts.transform !== false) {

--- a/test/cases.test.js
+++ b/test/cases.test.js
@@ -9,7 +9,7 @@ describe('cases', () => {
     it('should resolve quotes in transform step', () => {
         return compare(
             `background: svg-load('fixtures/font.svg');`,
-            `background: url("data:image/svg+xml;charset=utf-8,<svg font='%22Nelvetica Neue%22, sans-serif'/>");`
+            `background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' font='%22Nelvetica Neue%22, sans-serif'/>");`
         );
     });
 
@@ -21,8 +21,8 @@ describe('cases', () => {
             background: svg-load('fixtures/basic.svg');
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>");
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
             `
         ).then(result => {
             result.root.walkDecls(decl => {
@@ -48,7 +48,7 @@ describe('cases', () => {
             @svg-load icon url('fixtures/basic-black.svg') {}
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>")
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>")
             `
         ).then(result => {
             const messages = result.messages
@@ -92,7 +92,7 @@ describe('cases', () => {
             @svg-load icon url('basic-black.svg') {}
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>")
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>")
             `,
             {
                 from: 'fixtures/file.css',

--- a/test/extended.test.js
+++ b/test/extended.test.js
@@ -13,8 +13,8 @@ describe('extended syntax', () => {
             background: svg-inline(icon2);
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>");
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
             `
         );
     });
@@ -65,7 +65,7 @@ describe('extended syntax', () => {
             background: svg-inline(icon);
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic' fill='#fff' stroke='#000'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic' fill='#fff' stroke='#000'/>");
             `
         );
     });
@@ -80,7 +80,7 @@ describe('extended syntax', () => {
             background: svg-inline(icon);
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic-black' fill='#fff' stroke='#000'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic-black' fill='#fff' stroke='#000'/>");
             `
         );
     });
@@ -96,7 +96,7 @@ describe('extended syntax', () => {
             background: svg-inline(icon);
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='path'><path class='g1' fill='#fff'/><path class='g1' fill='#fff'/><path fill='#fff'/></svg>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='path'><path class='g1' fill='#fff'/><path class='g1' fill='#fff'/><path fill='#fff'/></svg>");
             `
         );
     });
@@ -112,7 +112,7 @@ describe('extended syntax', () => {
             background: svg-inline(icon);
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='path'><path class='g1' fill='#fff'/><path class='g1' fill='#fff'/><path fill='#000'/></svg>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='path'><path class='g1' fill='#fff'/><path class='g1' fill='#fff'/><path fill='#000'/></svg>");
             `
         );
     });

--- a/test/fixtures/basic-with-xmlns.svg
+++ b/test/fixtures/basic-with-xmlns.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' id="basic-with-xmls" ></svg>

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -13,8 +13,8 @@ describe('options', () => {
             background: svg-inline(icon);
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>");
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
             `,
             {
                 encode: false,
@@ -31,8 +31,8 @@ describe('options', () => {
             background: svg-inline(icon);
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>");
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
             `,
             {
                 encode: false,
@@ -49,13 +49,33 @@ describe('options', () => {
             background: svg-inline(icon);
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>");
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
             `,
             {
                 encode: false,
                 from: './fixtures/deeper/index.css',
                 path: './fixtures'
+            }
+        );
+    });
+
+    it('should ignore xmlns absence', () => {
+        return compare(
+            `background: svg-load('fixtures/basic.svg');`,
+            `background: url("data:image/svg+xml;charset=utf-8,%3Csvg id='basic'/%3E");`,
+            {
+                xmlnsize: false
+            }
+        );
+    });
+
+    it('should skip adding of xmlns if it is present in file', () => {
+        return compare(
+            `background: svg-load('fixtures/basic-with-xmlns.svg');`,
+            `background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic-with-xmls'/>");`,
+            {
+                encode: false
             }
         );
     });
@@ -75,6 +95,7 @@ describe('options', () => {
             `,
             {
                 encode: false,
+                xmlnsize: false,
                 transform(result, file) {
                     assert.equal(result, '<svg id="basic" fill="#fff"/>');
                     return file.split(/\\|\//).pop() + ': transformed content';
@@ -91,8 +112,8 @@ describe('options', () => {
             background: svg-inline(icon);
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,%3Csvg id='basic'/%3E");
-            background: url("data:image/svg+xml;charset=utf-8,%3Csvg id='basic'/%3E");
+            background: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/%3E");
+            background: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/%3E");
             `,
             {}
         );
@@ -111,7 +132,7 @@ describe('options', () => {
             `,
             {
                 encode(code) {
-                    assert.equal(code, `<svg id="basic"/>`);
+                    assert.equal(code, `<svg xmlns="http://www.w3.org/2000/svg" id="basic"/>`);
                     return '1234567890';
                 }
             }
@@ -136,7 +157,7 @@ describe('options', () => {
     it('should remove fill attributes with removeFill: true', () => {
         return compare(
             `background: svg-load('fixtures/fill.svg', fill="#fff");`,
-            `background: url("data:image/svg+xml;charset=utf-8,<svg fill='#fff'> <path/> </svg>");`,
+            `background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' fill='#fff'> <path/> </svg>");`,
             {
                 removeFill: true,
                 encode: false
@@ -151,8 +172,8 @@ describe('options', () => {
             background: svg-load('fixtures/fill-icon.svg', fill="#fff");
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,<svg fill='#fff'> <path fill='#000'/> </svg>");
-            background: url("data:image/svg+xml;charset=utf-8,<svg fill='#fff'> <rect/> </svg>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' fill='#fff'> <path fill='#000'/> </svg>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' fill='#fff'> <rect/> </svg>");
             `,
             {
                 removeFill: /-icon/,

--- a/test/short.test.js
+++ b/test/short.test.js
@@ -7,7 +7,7 @@ describe('short syntax', () => {
     it('should compile basic', () => {
         return compare(
             `background: svg-load('fixtures/basic.svg');`,
-            `background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>");`
+            `background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");`
         );
     });
 
@@ -33,7 +33,7 @@ describe('short syntax', () => {
     it('should compile fill param', () => {
         return compare(
             `background: svg-load('fixtures/basic.svg', fill=#fff);`,
-            `background: url("data:image/svg+xml;charset=utf-8,<svg id='basic' fill='#fff'/>");`
+            `background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic' fill='#fff'/>");`
         );
     });
 
@@ -44,8 +44,8 @@ describe('short syntax', () => {
             background: svg-load(fixtures/basic.svg, fill=#fff);
             `,
             `
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic'/>");
-            background: url("data:image/svg+xml;charset=utf-8,<svg id='basic' fill='#fff'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+            background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic' fill='#fff'/>");
             `
         );
     });
@@ -53,14 +53,14 @@ describe('short syntax', () => {
     it('should compile fill and stroke param', () => {
         return compare(
             `background: svg-load('fixtures/basic.svg', fill=#fff, stroke=#000);`,
-            `background: url("data:image/svg+xml;charset=utf-8,<svg id='basic' fill='#fff' stroke='#000'/>");`
+            `background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic' fill='#fff' stroke='#000'/>");`
         );
     });
 
     it('should compile fill param with colon syntax', () => {
         return compare(
             `background: svg-load('fixtures/basic.svg', fill: #fff);`,
-            `background: url("data:image/svg+xml;charset=utf-8,<svg id='basic' fill='#fff'/>");`
+            `background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic' fill='#fff'/>");`
         );
     });
 
@@ -90,14 +90,14 @@ describe('short syntax', () => {
     it('should override fill param', () => {
         return compare(
             `background: svg-load('fixtures/basic-black.svg', fill=#fff);`,
-            `background: url("data:image/svg+xml;charset=utf-8,<svg id='basic-black' fill='#fff'/>");`
+            `background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic-black' fill='#fff'/>");`
         );
     });
 
     it('should compile color functions', () => {
         return compare(
             `background: svg-load('fixtures/basic.svg', fill=rgb(255, 0, 0));`,
-            `background: url("data:image/svg+xml;charset=utf-8,<svg id='basic' fill='rgb(255, 0, 0)'/>");`
+            `background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic' fill='rgb(255, 0, 0)'/>");`
         );
     });
 });


### PR DESCRIPTION
Hi, @TrySound!

Thanks for your useful plugin! I think I found a way how to improve it a little bit :) Please consider adding SVG namespace automatically if it is not present in a file. There are no significant changes for users, but there are some critical benefits:

- Popular browsers *won't render* SVG files inlined to CSS without `xmlns`;
- According to [SVG Structure Specification](https://dev.w3.org/SVG/profiles/1.1F2/master/struct.html), in all cases, for compliance with the Namespaces in XML Recommendation, an SVG namespace declaration must be provided.

So I've added `xmlnsize` function which adds default `xmlns` if SVG file doesn't include it. Also, I've updated all the test files according to these changes.

What do you think about this? Please review and let me know if it might be improved.

Thanks!