### PR TITLE
Replace `path` with `paths` to support multiple paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ See [PostCSS] docs for examples for your environment.
 
 ### Options
 
-#### options.path
+#### options.paths
 
-Path to resolve URL.
+Array of paths to resolve URL. Paths are tried in order, until an existing file is found.
 
 Default: `false` - path will be relative to source file if it was specified.
 
@@ -85,7 +85,7 @@ Transforms SVG after `encode` function and generates URL.
 
 #### options.xmlns
 
-type: boolean  
+type: boolean
 default: true
 
 Adds `xmlns` attribute to SVG if not present.

--- a/lib/resolveId.js
+++ b/lib/resolveId.js
@@ -1,11 +1,24 @@
 const { dirname, resolve } = require("path");
+const { existsSync } = require("fs");
 
 module.exports = function resolveId(file, url, opts) {
-  if (opts.path) {
-    return resolve(opts.path, url);
+  if (opts.paths && opts.paths.length) {
+    let absolutePath;
+
+    for (let path of opts.paths) {
+      absolutePath = resolve(path, url);
+
+      if (existsSync(absolutePath)) {
+        return absolutePath;
+      }
+    }
+
+    return absolutePath;
   }
+
   if (file) {
     return resolve(dirname(file), url);
   }
+
   return resolve(url);
 };

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -18,7 +18,7 @@ test('should take file relatively to "from" option', () => {
   );
 });
 
-test('should take file relatively to "path" option', () => {
+test('should take file relatively to "paths" option', () => {
   return compare(
     `
     @svg-load icon url(basic.svg) {}
@@ -29,11 +29,11 @@ test('should take file relatively to "path" option', () => {
     background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
     background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
     `,
-    { from: "input.css", path: "./fixtures", encode: false }
+    { from: "input.css", paths: ["./fixtures"], encode: false }
   );
 });
 
-test('should prefer "path" option over "from"', () => {
+test('should find existing path from "paths" option', () => {
   return compare(
     `
     @svg-load icon url(basic.svg) {}
@@ -44,7 +44,30 @@ test('should prefer "path" option over "from"', () => {
     background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
     background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
     `,
-    { from: "./fixtures/deeper/index.css", path: "./fixtures", encode: false }
+    {
+      from: "input.css",
+      paths: ["./does_not_exist", "./fixtures"],
+      encode: false
+    }
+  );
+});
+
+test('should prefer "paths" option over "from"', () => {
+  return compare(
+    `
+    @svg-load icon url(basic.svg) {}
+    background: svg-load('basic.svg');
+    background: svg-inline(icon);
+    `,
+    `
+    background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+    background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+    `,
+    {
+      from: "./fixtures/deeper/index.css",
+      paths: ["./fixtures"],
+      encode: false
+    }
   );
 });
 


### PR DESCRIPTION
This PR is changed version of https://github.com/TrySound/postcss-inline-svg/pull/38.

Closes #38 and #34.

I decided to replace `path` with `paths` to have less confusion.

It's a breaking change.