### PR TITLE
Encode curly brackets by default. Fixes #48

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -4,7 +4,9 @@ function encode(code) {
     .replace(/</g, "%3C")
     .replace(/>/g, "%3E")
     .replace(/&/g, "%26")
-    .replace(/#/g, "%23");
+    .replace(/#/g, "%23")
+    .replace(/{/g, "%7B")
+    .replace(/}/g, "%7D");
 }
 
 function addXmlns(code) {


### PR DESCRIPTION
Per https://github.com/TrySound/postcss-inline-svg/issues/48 encode curly brackets by default. Thanks, @morgangraphics.