### PR TITLE
Added options.resolve function allowing resolveId override and options.paths will fallback to relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,16 @@ See [PostCSS] docs for examples for your environment.
 
 #### options.paths
 
-Array of paths to resolve URL. Paths are tried in order, until an existing file is found.
+Array of paths or function to resolve URL. Array paths are tried in order, until an existing file is found.
+Function recieves `file`, `url`, and `opts` arguments and expects to return an absolute path as a `string`.
+
+For example
+
+```js
+function paths(file, url, opts) {
+    return path.resolve('svgs', url);
+}
+```
 
 Default: `false` - path will be relative to source file if it was specified.
 

--- a/README.md
+++ b/README.md
@@ -53,18 +53,24 @@ See [PostCSS] docs for examples for your environment.
 
 #### options.paths
 
-Array of paths or function to resolve URL. Array paths are tried in order, until an existing file is found.
+Array of paths to resolve URL. Array paths are tried in order, until an existing file is found or will fallback to using the relative path.
+
+Default: `false` - path will be relative to source file if it was specified.
+
+#### options.resolve
+
+Function to resolve URL. This option will override the default file id resolver that uses "paths" option.
 Function recieves `file`, `url`, and `opts` arguments and expects to return an absolute path as a `string`.
 
 For example
 
 ```js
-function paths(file, url, opts) {
-    return path.resolve('svgs', url);
+function resolve(file, url, opts) {
+    return path.resolve('svg-folder', url);
 }
 ```
 
-Default: `false` - path will be relative to source file if it was specified.
+Default: `function` - internal resolver using "paths" option and relative path.
 
 #### options.removeFill
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,8 +45,8 @@ module.exports = postcss.plugin(
             const { params, selectors } = getRuleParams(node);
             const loader = {
               id:
-                typeof opts.paths === "function"
-                  ? opts.paths(file, url, opts)
+                typeof opts.resolve === "function"
+                  ? opts.resolve(file, url, opts)
                   : resolveId(file, url, opts),
               parent: file,
               params,
@@ -72,8 +72,8 @@ module.exports = postcss.plugin(
               ({ url, params, valueNode, parsedValue }) => {
                 const loader = {
                   id:
-                    typeof opts.paths === "function"
-                      ? opts.paths(file, url, opts)
+                    typeof opts.resolve === "function"
+                      ? opts.resolve(file, url, opts)
                       : resolveId(file, url, opts),
                   parent: file,
                   params,

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,10 @@ module.exports = postcss.plugin(
             const { name, url } = parseRuleDefinition(node.params);
             const { params, selectors } = getRuleParams(node);
             const loader = {
-              id: resolveId(file, url, opts),
+              id:
+                typeof opts.paths === "function"
+                  ? opts.paths(file, url, opts)
+                  : resolveId(file, url, opts),
               parent: file,
               params,
               selectors,
@@ -68,7 +71,10 @@ module.exports = postcss.plugin(
             statements.loaders.forEach(
               ({ url, params, valueNode, parsedValue }) => {
                 const loader = {
-                  id: resolveId(file, url, opts),
+                  id:
+                    typeof opts.paths === "function"
+                      ? opts.paths(file, url, opts)
+                      : resolveId(file, url, opts),
                   parent: file,
                   params,
                   selectors: {},

--- a/lib/resolveId.js
+++ b/lib/resolveId.js
@@ -12,8 +12,6 @@ module.exports = function resolveId(file, url, opts) {
         return absolutePath;
       }
     }
-
-    return absolutePath;
   }
 
   if (file) {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+const { resolve } = require("path");
 const { compare } = require("./utils.js");
 
 process.chdir(__dirname);
@@ -30,6 +31,25 @@ test('should take file relatively to "paths" option', () => {
     background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
     `,
     { from: "input.css", paths: ["./fixtures"], encode: false }
+  );
+});
+
+test('should resolve file using "paths" option as a function', () => {
+  return compare(
+    `
+    @svg-load icon url(basic.svg) {}
+    background: svg-load('basic.svg');
+    background: svg-inline(icon);
+    `,
+    `
+    background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+    background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+    `,
+    {
+      from: "input.css",
+      paths: (file, url, opts) => resolve("fixtures", url),
+      encode: false
+    }
   );
 });
 

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -91,6 +91,25 @@ test('should prefer "paths" option over "from"', () => {
   );
 });
 
+test('should fallback to relative option if "paths" option can\'t be resolved', () => {
+  return compare(
+    `
+    @svg-load icon url(fixtures/basic.svg) {}
+    background: svg-load('fixtures/basic.svg');
+    background: svg-inline(icon);
+    `,
+    `
+    background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+    background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+    `,
+    {
+      from: "input.css",
+      paths: ["./does_not_exist"],
+      encode: false
+    }
+  );
+});
+
 test("should ignore xmlns absence", () => {
   return compare(
     `background: svg-load('fixtures/basic.svg');`,

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -34,25 +34,6 @@ test('should take file relatively to "paths" option', () => {
   );
 });
 
-test('should resolve file using "paths" option as a function', () => {
-  return compare(
-    `
-    @svg-load icon url(basic.svg) {}
-    background: svg-load('basic.svg');
-    background: svg-inline(icon);
-    `,
-    `
-    background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
-    background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
-    `,
-    {
-      from: "input.css",
-      paths: (file, url, opts) => resolve("fixtures", url),
-      encode: false
-    }
-  );
-});
-
 test('should find existing path from "paths" option', () => {
   return compare(
     `
@@ -105,6 +86,25 @@ test('should fallback to relative option if "paths" option can\'t be resolved', 
     {
       from: "input.css",
       paths: ["./does_not_exist"],
+      encode: false
+    }
+  );
+});
+
+test('should resolve file path using the "resolve" option function', () => {
+  return compare(
+    `
+    @svg-load icon url(basic.svg) {}
+    background: svg-load('basic.svg');
+    background: svg-inline(icon);
+    `,
+    `
+    background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+    background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\' id='basic'/>");
+    `,
+    {
+      from: "input.css",
+      resolve: (file, url, opts) => resolve("fixtures", url),
       encode: false
     }
   );


### PR DESCRIPTION
Originally planned to extend the "paths" option, but deemed that to be too unclear. Instead added a new "resolve" option that take the same arguments as `resolveId(file, url, opts) => string`. As an added bonus internal `resolveId` will now attempt to resolve file relatively if "paths" don't return any meaningful results.