### PR TITLE
Remove Node v8 from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "node"
   - "10"
-  - "8"


### PR DESCRIPTION
Node v8 is no longer supported

REF: https://nodejs.org/en/about/releases/