### PR TITLE
feat: support setting currentColor directly

### DIFF
--- a/lib/load.js
+++ b/lib/load.js
@@ -5,7 +5,8 @@ const {
   removeFill,
   removeStroke,
   applyRootParams,
-  applySelectedParams
+  applySelectedParams,
+  applyCurrentColor
 } = require("./processors.js");
 
 function read(id) {
@@ -20,13 +21,19 @@ function read(id) {
   });
 }
 
-module.exports = function load(id, params, selectors, opts) {
+module.exports = function load(
+  id,
+  { currentColor, ...params },
+  selectors,
+  opts
+) {
   const processors = [
     removeFill(id, opts),
-    removeStroke(id,opts),
+    removeStroke(id, opts),
     applyRootParams(params),
-    applySelectedParams(selectors)
-  ];
+    applySelectedParams(selectors),
+    currentColor && applyCurrentColor(currentColor)
+  ].filter(Boolean);
   return read(id).then(data => {
     let code = render(data, ...processors);
 

--- a/lib/processors.js
+++ b/lib/processors.js
@@ -52,9 +52,32 @@ function applySelectedParams(selectors) {
   };
 }
 
+function addCurrentColorFillAttrib(currentColor) {
+  return element => {
+    element.attribs.fill = currentColor;
+  };
+}
+function addCurrentColorStrokeAttrib(currentColor) {
+  return element => {
+    element.attribs.stroke = currentColor;
+  };
+}
+
+function applyCurrentColor(currentColor) {
+  return dom => {
+    selectAll("[fill=currentColor]", dom).forEach(
+      addCurrentColorFillAttrib(currentColor)
+    );
+    selectAll("[stroke=currentColor]", dom).forEach(
+      addCurrentColorStrokeAttrib(currentColor)
+    );
+  };
+}
+
 module.exports = {
   removeFill,
   removeStroke,
   applyRootParams,
-  applySelectedParams
+  applySelectedParams,
+  applyCurrentColor
 };

--- a/test/fixtures/current-color-fill.svg
+++ b/test/fixtures/current-color-fill.svg
@@ -1,0 +1,3 @@
+<svg>
+    <path fill="currentColor" />
+</svg>

--- a/test/short.test.js
+++ b/test/short.test.js
@@ -55,6 +55,14 @@ test("should compile fill and stroke param", () => {
   );
 });
 
+test("should compile currentColor param", () => {
+  return compare(
+    `background: svg-load('fixtures/current-color-fill.svg', currentColor=#fff);`,
+    `background: url("data:image/svg+xml;charset=utf-8,<svg xmlns=\'http://www.w3.org/2000/svg\'> <path fill='#fff'/> </svg>");`,
+    { from: "input.css", encode: false }
+  );
+});
+
 test("should compile fill param with colon syntax", () => {
   return compare(
     `background: svg-load('fixtures/basic.svg', fill: #fff);`,


### PR DESCRIPTION
Replacing currentColor instead of setting `color` as a root param minifies a bit better, especially on small SVGs.