### PR TITLE
Migrate to PostCSS 8

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ function stringifyInliner(inliner) {
     inliner.node.value = String(inliner.parsedValue);
   }
 }
+
 module.exports = (opts = {}) => {
   return {
     postcssPlugin: "postcss-inline-svg",

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-const postcss = require("postcss");
 const { parseRuleDefinition, getRuleParams } = require("./parseRule.js");
 const parseDeclValue = require("./parseDeclValue.js");
 const resolveId = require("./resolveId.js");
@@ -27,102 +26,112 @@ function stringifyInliner(inliner) {
     inliner.node.value = String(inliner.parsedValue);
   }
 }
+module.exports = (opts = {}) => {
+  return {
+    postcssPlugin: "postcss-inline-svg",
 
-module.exports = postcss.plugin(
-  "postcss-inline-svg",
-  (opts = {}) => (css, result) => {
-    const loadersMap = {};
-    const loaders = [];
-    const inliners = [];
+    prepare(result) {
+      const loadersMap = {};
+      const loaders = [];
+      const inliners = [];
 
-    css.walk((node) => {
-      if (node.type === "atrule") {
-        if (node.name === "svg-load") {
-          try {
-            const file =
-              node.source && node.source.input && node.source.input.file;
-            const { name, url } = parseRuleDefinition(node.params);
-            const { params, selectors } = getRuleParams(node);
-            const loader = {
-              id: resolveId(file, url, opts),
-              parent: file,
-              params,
-              selectors,
-              node,
-            };
-            loaders.push(loader);
-            loadersMap[name] = loader;
-          } catch (e) {
-            node.warn(result, e.message);
+      return {
+        AtRule: {
+          "svg-load": (node) => {
+            try {
+              const file =
+                node.source && node.source.input && node.source.input.file;
+              const { name, url } = parseRuleDefinition(node.params);
+              const { params, selectors } = getRuleParams(node);
+              const loader = {
+                id: resolveId(file, url, opts),
+                parent: file,
+                params,
+                selectors,
+                node,
+              };
+              loaders.push(loader);
+              loadersMap[name] = loader;
+            } catch (e) {
+              node.warn(result, e.message);
+            }
+          },
+        },
+
+        Declaration(node) {
+          if (
+            node.value.includes("svg-load(") ||
+            node.value.includes("svg-inline(")
+          ) {
+            try {
+              const file =
+                node.source && node.source.input && node.source.input.file;
+              const statements = parseDeclValue(node.value);
+              statements.loaders.forEach(
+                ({ url, params, valueNode, parsedValue }) => {
+                  const loader = {
+                    id: resolveId(file, url, opts),
+                    parent: file,
+                    params,
+                    selectors: {},
+                    node,
+                  };
+                  loaders.push(loader);
+                  inliners.push({
+                    loader,
+                    node,
+                    valueNode,
+                    parsedValue,
+                  });
+                }
+              );
+              statements.inliners.forEach(
+                ({ name, valueNode, parsedValue }) => {
+                  const loader = loadersMap[name];
+                  if (loader) {
+                    inliners.push({
+                      loader,
+                      node,
+                      valueNode,
+                      parsedValue,
+                    });
+                  } else {
+                    node.warn(result, `"${name}" svg is not defined`);
+                  }
+                }
+              );
+            } catch (e) {
+              node.warn(result, e.message);
+            }
           }
-        }
-      } else if (node.type === "decl") {
-        if (
-          node.value.indexOf("svg-load(") !== -1 ||
-          node.value.indexOf("svg-inline(") !== -1
-        ) {
-          try {
-            const file =
-              node.source && node.source.input && node.source.input.file;
-            const statements = parseDeclValue(node.value);
-            statements.loaders.forEach(
-              ({ url, params, valueNode, parsedValue }) => {
-                const loader = {
-                  id: resolveId(file, url, opts),
-                  parent: file,
-                  params,
-                  selectors: {},
-                  node,
-                };
-                loaders.push(loader);
-                inliners.push({
-                  loader,
-                  node,
-                  valueNode,
-                  parsedValue,
-                });
-              }
-            );
-            statements.inliners.forEach(({ name, valueNode, parsedValue }) => {
-              const loader = loadersMap[name];
-              if (loader) {
-                inliners.push({
-                  loader,
-                  node,
-                  valueNode,
-                  parsedValue,
-                });
-              } else {
-                node.warn(result, `"${name}" svg is not defined`);
-              }
-            });
-          } catch (e) {
-            node.warn(result, e.message);
-          }
-        }
-      }
-    });
+        },
 
-    const promises = loaders.map((loader) => {
-      return load(loader.id, loader.params, loader.selectors, opts)
-        .then((code) => {
-          loader.svg = code;
-          result.messages.push({
-            type: "dependency",
-            file: loader.id,
-            parent: loader.parent,
+        OnceExit() {
+          const promises = loaders.map((loader) => {
+            return load(loader.id, loader.params, loader.selectors, opts)
+              .then((code) => {
+                loader.svg = code;
+                result.messages.push({
+                  type: "dependency",
+                  file: loader.id,
+                  parent: loader.parent,
+                });
+              })
+              .catch((err) => {
+                loader.error = true;
+                loader.node.warn(result, err.message);
+              });
           });
-        })
-        .catch((err) => {
-          loader.error = true;
-          loader.node.warn(result, err.message);
-        });
-    });
 
-    return Promise.all(promises).then(() => {
-      loaders.forEach(removeLoader);
-      inliners.forEach(applyInliner);
-      inliners.forEach(stringifyInliner);
-    });
-  }
-);
+          return Promise.all(promises).then(() => {
+            loaders.forEach(removeLoader);
+            inliners.forEach(applyInliner);
+            inliners.forEach(stringifyInliner);
+          });
+        },
+      };
+    },
+  };
+};
+
+module.exports.postcss = true;

--- a/package.json
+++ b/package.json
@@ -38,13 +38,16 @@
     "css-select": "^3.1.0",
     "dom-serializer": "^1.1.0",
     "htmlparser2": "^5.0.1",
-    "postcss": "^7.0.17",
     "postcss-value-parser": "^4.0.0"
+  },
+  "peerDependencies": {
+    "postcss": "^8.1.4"
   },
   "devDependencies": {
     "husky": "^4.3.0",
     "jest": "^26.6.1",
     "lint-staged": "^10.5.0",
+    "postcss": "^8.1.4",
     "prettier": "^2.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,7 +906,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^2.0.0, chalk@^2.4.2:
+chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1018,6 +1018,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+colorette@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
+  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -1951,7 +1956,7 @@ is-wsl@^2.2.0:
   dependencies:
     is-docker "^2.0.0"
 
-isarray@1.0.0:
+isarray@1.0.0, isarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -2525,6 +2530,14 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+line-column@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/line-column/-/line-column-1.0.2.tgz#d25af2936b6f4849172b312e4792d1d987bc34a2"
+  integrity sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=
+  dependencies:
+    isarray "^1.0.0"
+    isobject "^2.0.0"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -2703,6 +2716,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+nanoid@^3.1.15:
+  version "3.1.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
+  integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -2994,14 +3012,15 @@ postcss-value-parser@^4.0.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
-postcss@^7.0.17:
-  version "7.0.35"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
-  integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
+postcss@^8.1.4:
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.1.4.tgz#356dfef367a70f3d04347f74560c85846e20e4c1"
+  integrity sha512-LfqcwgMq9LOd8pX7K2+r2HPitlIGC5p6PoZhVELlqhh2YGDVcXKpkCseqan73Hrdik6nBd2OvoDPUaP/oMj9hQ==
   dependencies:
-    chalk "^2.4.2"
+    colorette "^1.2.1"
+    line-column "^1.0.2"
+    nanoid "^3.1.15"
     source-map "^0.6.1"
-    supports-color "^6.1.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -3560,13 +3579,6 @@ supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
-
-supports-color@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
-  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
 


### PR DESCRIPTION
Some maintenance tasks together with upgrade to PostCSS 8. [Migration guide](https://evilmartians.com/chronicles/postcss-8-plugin-migration).

Plugin changes are better reviewed with whitespace diff disabled.